### PR TITLE
sdm845: add new "axolotl" target

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -20,7 +20,7 @@
 # to only building on ARM if they include assembly. Individual makefiles
 # are responsible for having their own logic, for fine-grained control.
 
-ifneq ($(filter beryllium enchilada, $(TARGET_DEVICE)),)
+ifneq ($(filter axolotl beryllium enchilada, $(TARGET_DEVICE)),)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -10,9 +10,11 @@
 #
 
 PRODUCT_MAKEFILES := \
+    $(LOCAL_DIR)/axolotl.mk \
     $(LOCAL_DIR)/beryllium.mk \
     $(LOCAL_DIR)/enchilada.mk
 
 COMMON_LUNCH_CHOICES := \
+    axolotl-userdebug \
     beryllium-userdebug \
     enchilada-userdebug

--- a/axolotl.mk
+++ b/axolotl.mk
@@ -1,0 +1,23 @@
+ifndef TARGET_KERNEL_USE
+TARGET_KERNEL_USE := mainline
+endif
+
+KERNEL_MODS := $(wildcard device/generic/sdm845/prebuilt-kernel/android-$(TARGET_KERNEL_USE)/*.ko)
+
+# Following modules go to vendor partition
+VENDOR_KERN_MODS :=
+BOARD_VENDOR_KERNEL_MODULES := $(filter $(VENDOR_KERN_MODS),$(KERNEL_MODS))
+
+# All other modules go to ramdisk
+BOARD_GENERIC_RAMDISK_KERNEL_MODULES := $(filter-out $(VENDOR_KERN_MODS),$(KERNEL_MODS))
+
+# Inherit the full_base and device configurations
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+$(call inherit-product, device/generic/sdm845/axolotl/device.mk)
+$(call inherit-product, device/generic/sdm845/device-common.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)
+
+# Product overrides
+PRODUCT_BRAND  := AOSP
+PRODUCT_DEVICE := axolotl
+PRODUCT_NAME   := axolotl

--- a/axolotl/BoardConfig.mk
+++ b/axolotl/BoardConfig.mk
@@ -1,0 +1,54 @@
+include device/generic/sdm845/BoardConfigCommon.mk
+
+# Board Information
+TARGET_BOOTLOADER_BOARD_NAME := axolotl
+TARGET_BOARD_PLATFORM := axolotl
+
+# Kernel/boot.img Configuration
+BOARD_KERNEL_CMDLINE += androidboot.hardware=axolotl
+
+##### Partition handling
+
+BOARD_DYNAMIC_PARTITION_ENABLE := true
+TARGET_USE_DYNAMIC_PARTITIONS := true
+
+# Define the Dynamic Partition sizes and groups.
+BOARD_SUPER_PARTITION_SIZE := 12884901888
+BOARD_SUPER_PARTITION_GROUPS := axolotl_dynamic_partitions
+BOARD_AXOLOTL_DYNAMIC_PARTITIONS_SIZE := 6438256640
+BOARD_AXOLOTL_DYNAMIC_PARTITIONS_PARTITION_LIST := \
+    product \
+    system \
+    system_ext \
+    vendor \
+
+# Set error limit to BOARD_SUPER_PARTITON_SIZE - 500MB
+BOARD_SUPER_PARTITION_ERROR_LIMIT := 12360613888
+
+# boot.img
+BOARD_BOOTIMAGE_PARTITION_SIZE := 0x04000000
+
+# metadata.img
+BOARD_METADATAIMAGE_PARTITION_SIZE := 16777216
+BOARD_USES_METADATA_PARTITION := true
+
+# product.img
+BOARD_USES_PRODUCTIMAGE := true
+BOARD_PRODUCTIMAGE_FILE_SYSTEM_TYPE := ext4
+TARGET_COPY_OUT_PRODUCT := product
+
+# recovery.img
+BOARD_RECOVERYIMAGE_PARTITION_SIZE := 0x06000000
+
+# super.img
+BOARD_BUILD_SUPER_IMAGE_BY_DEFAULT := true
+
+# system_ext.img
+BOARD_SYSTEM_EXTIMAGE_FILE_SYSTEM_TYPE := ext4
+TARGET_COPY_OUT_SYSTEM_EXT := system_ext
+
+# userdata.img
+BOARD_USERDATAIMAGE_PARTITION_SIZE := 10737418240
+# Stock ships with F2FS but we force it to ext4
+BOARD_USERDATAIMAGE_FILE_SYSTEM_TYPE := ext4
+#BOARD_USERDATAIMAGE_FILE_SYSTEM_TYPE := f2fs

--- a/axolotl/device.mk
+++ b/axolotl/device.mk
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2011 The Android Open-Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PRODUCT_COPY_FILES := \
+    $(LOCAL_PATH)/fstab.ramdisk:$(TARGET_COPY_OUT_RAMDISK)/fstab.axolotl \
+    $(LOCAL_PATH)/fstab.ramdisk:$(TARGET_COPY_OUT_VENDOR)/etc/fstab.axolotl \
+    device/generic/sdm845/init.common.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.axolotl.rc \
+    device/generic/sdm845/init.common.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.axolotl.usb.rc \
+    device/generic/sdm845/common.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/axolotl.kl
+
+# Audio
+PRODUCT_PACKAGES += audio.primary.axolotl
+
+# Lights
+PRODUCT_PACKAGES += lights.axolotl
+
+# Dynamic Partitions
+PRODUCT_BUILD_SUPER_PARTITION := true
+PRODUCT_USE_DYNAMIC_PARTITIONS := true
+PRODUCT_USE_DYNAMIC_PARTITION_SIZE := true

--- a/axolotl/fstab.ramdisk
+++ b/axolotl/fstab.ramdisk
@@ -1,0 +1,10 @@
+system         /system         ext4    noatime,ro,errors=panic    wait,logical,first_stage_mount
+system_ext     /system_ext     ext4    noatime,ro,errors=panic    wait,logical,first_stage_mount
+product        /product        ext4    noatime,ro,errors=panic    wait,logical,first_stage_mount
+vendor         /vendor         ext4    noatime,ro,errors=panic    wait,logical,first_stage_mount
+
+/dev/block/by-name/metadata    /metadata    ext4    noatime,nosuid,nodev,discard,data=journal,commit=1    wait,formattable,first_stage_mount,check
+/dev/block/by-name/misc        /misc        emmc    defaults    defaults
+/dev/block/by-name/userdata    /data        ext4    discard,noatime,noauto_da_alloc,data=ordered,user_xattr,barrier=1    wait,formattable,quota
+
+/devices/platform/soc@0/8804000.sdhci/mmc_host/mmc*	auto	auto	defaults	voldmanaged=sdcard1:auto

--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -1,4 +1,4 @@
-ifneq ($(filter beryllium enchilada, $(TARGET_DEVICE)),)
+ifneq ($(filter axolotl beryllium enchilada, $(TARGET_DEVICE)),)
 
 IMAGE_GZ := device/generic/sdm845/prebuilt-kernel/android-$(TARGET_KERNEL_USE)/Image.gz
 DTB := $(wildcard device/generic/sdm845/prebuilt-kernel/android-$(TARGET_KERNEL_USE)/*.dtb)

--- a/sepolicy/genfs_contexts
+++ b/sepolicy/genfs_contexts
@@ -1,3 +1,4 @@
+genfscon sysfs   /devices/platform/88f00000.memory/rmtfs					u:object_r:sysfs_rmtfs:s0 # Axolotl
 genfscon sysfs   /devices/platform/f6301000.memory/rmtfs					u:object_r:sysfs_rmtfs:s0 # Beryllium
 genfscon sysfs   /devices/platform/f5b01000.memory/rmtfs					u:object_r:sysfs_rmtfs:s0 # Enchilada
 genfscon sysfs   /devices/platform/remoteproc-adsp/remoteproc					u:object_r:sysfs_remoteproc:s0


### PR DESCRIPTION
This adds initial support for the SHIFT6mq (axolotl).
It launched with Android 10, makes use of dynamic partitions
and has A/B.

A/B is ignored in this bringup and will be added at a later
stage.

-----

Depends on #6 