### PR TITLE
sepolicy: Add correct backlight sysfs_lights path for Beryllium

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -20,6 +20,7 @@
 /sys/devices/platform/soc@0/c440000.spmi/spmi-0/0-00/c440000.spmi:pmic@0:rtc@6000/rtc	u:object_r:sysfs_rtc:s0
 
 /sys/class/backlight(/.*)?								u:object_r:sysfs_lights:s0
+/sys/devices/platform/soc@0/c440000.spmi/spmi-0/0-03/c440000.spmi:pmic@3:leds@d800/backlight	u:object_r:sysfs_lights:s0
 
 /sys/class/power_supply(/.*)?								u:object_r:sysfs_power:s0
 /sys/devices/platform/soc@0/.*/power_supply(/.*)?					u:object_r:sysfs_power:s0

--- a/sepolicy/genfs_contexts
+++ b/sepolicy/genfs_contexts
@@ -8,3 +8,4 @@ genfscon sysfs   /devices/platform/soc@0/ae00000.mdss						u:object_r:sysfs_gpu:
 genfscon sysfs   /devices/platform/soc@0/c440000.spmi/spmi-0/0-00/c440000.spmi:pmic@0:rtc@6000	u:object_r:sysfs_rtc:s0
 genfscon sysfs   /devices/platform/soc@0/c440000.spmi/spmi-0/0-02/c440000.spmi:pmic@2:fuel-gauge@4000/power_supply	u:object_r:sysfs_power:s0
 genfscon sysfs   /devices/platform/soc@0/c440000.spmi/spmi-0/0-02/c440000.spmi:pmic@2:smb2@1000/power_supply		u:object_r:sysfs_power:s0
+genfscon sysfs   /devices/platform/soc@0/c440000.spmi/spmi-0/0-03/c440000.spmi:pmic@3:leds@d800/backlight		u:object_r:sysfs_lights:s0


### PR DESCRIPTION
Fixes the broken brightness control on Beryllium.

Signed-off-by: Amit Pundir <amit.pundir@linaro.org>