### PR TITLE
rmtfs: Update to latest version

### DIFF
--- a/qcom/rmtfs/.gitignore
+++ b/qcom/rmtfs/.gitignore
@@ -1,0 +1,3 @@
+rmtfs
+*.o
+rmtfs.service

--- a/qcom/rmtfs/rmtfs.c
+++ b/qcom/rmtfs/rmtfs.c
@@ -220,6 +220,10 @@ static void rmtfs_iovec(int sock, struct qrtr_packet *pkt)
 respond:
 	dbgprintf("[RMTFS] iovec %d, %sforced => (%d:%d)\n", caller_id, force ? "" : "not ",
 							     resp.result.result, resp.result.error);
+
+	if (is_write)
+		storage_sync(rmtfd);
+
 	for (i = 0; i < num_entries; i++) {
 		dbgprintf("[RMTFS]       %s %d:%d 0x%x\n", is_write ? "write" : "read",
 							   entries[i].sector_addr,
@@ -445,7 +449,10 @@ static int run_rmtfs(int rprocfd)
 		rproc_start();
 
 	for (;;) {
-		if (rprocfd >= 0 && sig_int_count == 1 && !sig_int_handled) {
+		if (sig_int_count == 1 && !sig_int_handled) {
+			if (rprocfd < 0)
+				break;
+
 			rproc_stop();
 			sig_int_handled = true;
 		} else if (sig_int_count > 1) {
@@ -482,7 +489,7 @@ static int run_rmtfs(int rprocfd)
 	return ret;
 }
 
-static void sig_int_handler(int signo __unused)
+static void sig_int_handler(int signo)
 {
 	sig_int_count++;
 }

--- a/qcom/rmtfs/rmtfs.h
+++ b/qcom/rmtfs/rmtfs.h
@@ -34,6 +34,7 @@ int storage_get_error(const struct rmtfd *rmtfd);
 void storage_exit(void);
 ssize_t storage_pread(const struct rmtfd *rmtfd, void *buf, size_t nbyte, off_t offset);
 ssize_t storage_pwrite(struct rmtfd *rmtfd, const void *buf, size_t nbyte, off_t offset);
+int storage_sync(struct rmtfd *rmtfd);
 
 int rproc_init(void);
 int rproc_start(void);

--- a/qcom/rmtfs/rproc.c
+++ b/qcom/rmtfs/rproc.c
@@ -13,13 +13,75 @@
 #include "rmtfs.h"
 
 #define RPROC_BASE_PATH		"/sys/bus/platform/drivers/qcom-q6v5-mss/"
+#define RPROC_CLASS_PATH	"/sys/class/remoteproc/"
 
 static pthread_t start_thread;
 static pthread_t stop_thread;
 static int rproc_state_fd;
 static int rproc_pipe[2];
 
-int rproc_init(void)
+static int rproc_init_by_modalias(void)
+{
+	struct dirent *rproc_de;
+	char modalias[256];
+	DIR *base_dir;
+	int modalias_fd;
+	int rproc_fd;
+	int state_fd = -1;
+	int base_fd;
+	int ret;
+
+	base_fd = open(RPROC_CLASS_PATH, O_RDONLY | O_DIRECTORY);
+	if (base_fd < 0)
+		return -1;
+
+	base_dir = fdopendir(base_fd);
+	if (!base_dir) {
+		fprintf(stderr, "failed to open remoteproc class path\n");
+		close(base_fd);
+		return -1;
+	}
+
+	while (state_fd < 0 && (rproc_de = readdir(base_dir)) != NULL) {
+		if (!strcmp(rproc_de->d_name, ".") ||
+		    !strcmp(rproc_de->d_name, ".."))
+			continue;
+
+		rproc_fd = openat(base_fd, rproc_de->d_name, O_RDONLY | O_DIRECTORY);
+		if (rproc_fd < 0)
+			continue;
+
+		modalias_fd = openat(rproc_fd, "device/modalias", O_RDONLY);
+		if (modalias_fd < 0)
+			goto close_rproc_fd;
+
+		ret = read(modalias_fd, modalias, sizeof(modalias) - 1);
+		if (ret < 0)
+			goto close_modalias_fd;
+		modalias[ret] = '\0';
+
+		if (!strstr(modalias, "-mpss-pas") && !strstr(modalias, "-mss-pil"))
+			goto close_modalias_fd;
+
+		state_fd = openat(rproc_fd, "state", O_WRONLY);
+		if (state_fd < 0) {
+			fprintf(stderr,
+				"unable to open remoteproc \"state\" control file of %s\n",
+				rproc_de->d_name);
+		}
+
+close_modalias_fd:
+		close(modalias_fd);
+close_rproc_fd:
+		close(rproc_fd);
+	}
+	closedir(base_dir);
+	close(base_fd);
+
+	return state_fd;
+}
+
+static int rproc_init_by_mss_driver(void)
 {
 	struct dirent *device_de;
 	struct dirent *rproc_de;
@@ -28,10 +90,8 @@ int rproc_init(void)
 	DIR *base_dir;
 	int device_fd;
 	int rproc_fd;
+	int state_fd = -1;
 	int base_fd;
-	int ret;
-
-	rproc_state_fd = -1;
 
 	base_fd = open(RPROC_BASE_PATH, O_RDONLY | O_DIRECTORY);
 	if (base_fd < 0)
@@ -44,7 +104,7 @@ int rproc_init(void)
 		return -1;
 	}
 
-	while (rproc_state_fd < 0 && (device_de = readdir(base_dir)) != NULL) {
+	while (state_fd < 0 && (device_de = readdir(base_dir)) != NULL) {
 		if (!strcmp(device_de->d_name, ".") ||
 		    !strcmp(device_de->d_name, ".."))
 			continue;
@@ -60,7 +120,7 @@ int rproc_init(void)
 		}
 
 		rproc_dir = fdopendir(rproc_base_fd);
-		while (rproc_state_fd < 0 && (rproc_de = readdir(rproc_dir)) != NULL) {
+		while (state_fd < 0 && (rproc_de = readdir(rproc_dir)) != NULL) {
 			if (!strcmp(rproc_de->d_name, ".") ||
 			    !strcmp(rproc_de->d_name, ".."))
 				continue;
@@ -69,8 +129,8 @@ int rproc_init(void)
 			if (rproc_fd < 0)
 				continue;
 
-			rproc_state_fd = openat(rproc_fd, "state", O_WRONLY);
-			if (rproc_state_fd < 0) {
+			state_fd = openat(rproc_fd, "state", O_WRONLY);
+			if (state_fd < 0) {
 				fprintf(stderr,
 					"unable to open remoteproc \"state\" control file of %s\n",
 					device_de->d_name);
@@ -86,41 +146,64 @@ int rproc_init(void)
 	closedir(base_dir);
 	close(base_fd);
 
-	if (rproc_state_fd < 0)
-		return -1;
+	return state_fd;
+}
+
+int rproc_init(void)
+{
+	int state_fd;
+	int ret;
+
+	state_fd = rproc_init_by_modalias();
+	if (state_fd < 0) {
+		state_fd = rproc_init_by_mss_driver();
+		if (state_fd < 0)
+			return -1;
+	}
 
 	ret = pipe(rproc_pipe);
 	if (ret < 0) {
-		close(rproc_state_fd);
+		close(state_fd);
 		return -1;
 	}
+
+	rproc_state_fd = state_fd;
 
 	return rproc_pipe[0];
 }
 
-static void *do_rproc_start(void *unused __unused)
+static void *do_rproc_start(void *unused)
 {
 	ssize_t ret;
 
 	ret = pwrite(rproc_state_fd, "start", 5, 0);
-	if (ret < 4)
-		fprintf(stderr, "failed to update start state\n");
+	if (ret < 4) {
+		fprintf(stderr, "failed to update start state: %s\n",
+			strerror(errno));
+	}
 
 	return NULL;
 }
 
 int rproc_start()
 {
-	return pthread_create(&start_thread, NULL, do_rproc_start, NULL);
+	pthread_attr_t attr;
+
+	pthread_attr_init(&attr);
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+	return pthread_create(&start_thread, &attr, do_rproc_start, NULL);
 }
 
-static void *do_rproc_stop(void *unused __unused)
+static void *do_rproc_stop(void *unused)
 {
 	ssize_t ret;
 
 	ret = pwrite(rproc_state_fd, "stop", 4, 0);
-	if (ret < 4)
-		fprintf(stderr, "failed to update stop state\n");
+	if (ret < 4) {
+		fprintf(stderr, "failed to update stop state: %s\n",
+			strerror(errno));
+	}
 
 	ret = write(rproc_pipe[1], "Y", 1);
 	if (ret != 1) {
@@ -133,5 +216,10 @@ static void *do_rproc_stop(void *unused __unused)
 
 int rproc_stop(void)
 {
-	return pthread_create(&stop_thread, NULL, do_rproc_stop, NULL);
+	pthread_attr_t attr;
+
+	pthread_attr_init(&attr);
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+	return pthread_create(&stop_thread, &attr, do_rproc_stop, NULL);
 }

--- a/qcom/rmtfs/sharedmem.c
+++ b/qcom/rmtfs/sharedmem.c
@@ -256,7 +256,7 @@ err_close_fd:
 	return -saved_errno;
 }
 
-static int rmtfs_mem_open_uio(struct rmtfs_mem *rmem __unused, int client_id __unused)
+static int rmtfs_mem_open_uio(struct rmtfs_mem *rmem, int client_id)
 {
 	fprintf(stderr, "uio access is not supported on ANDROID yet\n");
 	return -EINVAL;
@@ -330,7 +330,7 @@ int64_t rmtfs_mem_alloc(struct rmtfs_mem *rmem, size_t alloc_size)
 	return rmem->address;
 }
 
-void rmtfs_mem_free(struct rmtfs_mem *rmem __unused)
+void rmtfs_mem_free(struct rmtfs_mem *rmem)
 {
 }
 

--- a/qcom/rmtfs/storage.c
+++ b/qcom/rmtfs/storage.c
@@ -202,7 +202,7 @@ ssize_t storage_pread(const struct rmtfd *rmtfd, void *buf, size_t nbyte, off_t 
 	if (!storage_read_only) {
 		n = pread(rmtfd->fd, buf, nbyte, offset);
 	} else {
-		n = MIN(nbyte, rmtfd->shadow_len - offset);
+		n = MIN((ssize_t)nbyte, (ssize_t)rmtfd->shadow_len - offset);
 		if (n > 0)
 			memcpy(buf, (char*)rmtfd->shadow_buf + offset, n);
 		else

--- a/sepolicy/rmtfs.te
+++ b/sepolicy/rmtfs.te
@@ -10,6 +10,6 @@ allow rmtfs self:capability net_admin;
 allow rmtfs self:qipcrtr_socket { bind create getattr read setopt write };
 allow rmtfs sysfs_mss:dir { open read search };
 allow rmtfs sysfs_remoteproc:dir { open read search };
-allow rmtfs sysfs_remoteproc:file { open write };
+allow rmtfs sysfs_remoteproc:file { open read write };
 allow rmtfs sysfs_rmtfs:dir search;
 allow rmtfs sysfs_rmtfs:file { open read };


### PR DESCRIPTION
See individual commits for details.

The "fix segfault" commit should be sent upstream, but I still need to validate why this crash doesn't happen on postmarketOS and only here. Either the function doesn't get called with the parameters that gets it crashed or the signed/unsigned problem is a bit undefined and gets handled differently on musl+gcc