### PR TITLE
Remove sysfs_gpu type definition

### DIFF
--- a/shared/sepolicy/file.te
+++ b/shared/sepolicy/file.te
@@ -1,4 +1,3 @@
-type sysfs_gpu, fs_type, sysfs_type;
 type sysfs_lights, fs_type, sysfs_type;
 type sysfs_mss, fs_type, sysfs_type;
 type sysfs_rmtfs, fs_type, sysfs_type;


### PR DESCRIPTION
cherry-picked from upstream device/linaro/dragonboard project.

... as it has moved to system/sepolicy.

Bug: b/161819018
Test: presubmit
Change-Id: I77afd0d7019e0ea0cc475de3817bc2c8e7fcd4bd
Merged-In: I77afd0d7019e0ea0cc475de3817bc2c8e7fcd4bd
Signed-off-by: Amit Pundir <amit.pundir@linaro.org>