### PR TITLE
Use TARGET_SCREEN_DENSITY

### DIFF
--- a/axolotl/BoardConfig.mk
+++ b/axolotl/BoardConfig.mk
@@ -3,6 +3,7 @@ include device/generic/sdm845/shared/BoardConfig.mk
 # Board Information
 TARGET_BOOTLOADER_BOARD_NAME := axolotl
 TARGET_BOARD_PLATFORM := axolotl
+TARGET_SCREEN_DENSITY := 400
 
 # Kernel/boot.img Configuration
 BOARD_KERNEL_CMDLINE += androidboot.hardware=axolotl

--- a/beryllium/BoardConfig.mk
+++ b/beryllium/BoardConfig.mk
@@ -4,6 +4,7 @@ include device/generic/sdm845/shared/BoardConfig.mk
 # Board Information
 TARGET_BOOTLOADER_BOARD_NAME := beryllium
 TARGET_BOARD_PLATFORM := beryllium
+TARGET_SCREEN_DENSITY := 400
 
 # Kernel/boot.img Configuration
 BOARD_KERNEL_CMDLINE     += androidboot.hardware=beryllium

--- a/enchilada/BoardConfig.mk
+++ b/enchilada/BoardConfig.mk
@@ -4,6 +4,7 @@ include device/generic/sdm845/shared/BoardConfig.mk
 # Board Information
 TARGET_BOOTLOADER_BOARD_NAME := enchilada
 TARGET_BOARD_PLATFORM := enchilada
+TARGET_SCREEN_DENSITY := 400
 
 # Kernel/boot.img Configuration
 BOARD_KERNEL_CMDLINE     += androidboot.hardware=enchilada

--- a/shared/device.mk
+++ b/shared/device.mk
@@ -51,7 +51,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.gralloc=minigbm_msm \
     ro.hardware.hwcomposer=drm \
     debug.sf.no_hw_vsync=1 \
-    ro.sf.lcd_density=400 \
     ro.opengles.version=196609
 
 #


### PR DESCRIPTION
This variable is used to auto-populate the ro.sf.lcd_density as
well as selecting density bucket for resources in recovery.

---

Maybe time to put the actual values for the 3 devices here and not just a generic 400?

Also this variable is used for generating the correct graphics for recovery, once that's built.