### PR TITLE
Add Support for OnePlus 6T

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -20,7 +20,7 @@
 # to only building on ARM if they include assembly. Individual makefiles
 # are responsible for having their own logic, for fine-grained control.
 
-ifneq ($(filter axolotl beryllium enchilada, $(TARGET_DEVICE)),)
+ifneq ($(filter axolotl beryllium enchilada fajita, $(TARGET_DEVICE)),)
 
 LOCAL_PATH := $(call my-dir)
 

--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -12,9 +12,11 @@
 PRODUCT_MAKEFILES := \
     axolotl:$(LOCAL_DIR)/axolotl/axolotl.mk \
     beryllium:$(LOCAL_DIR)/beryllium/beryllium.mk \
-    enchilada:$(LOCAL_DIR)/enchilada/enchilada.mk
+    enchilada:$(LOCAL_DIR)/enchilada/enchilada.mk \
+    fajita:$(LOCAL_DIR)/fajita/fajita.mk
 
 COMMON_LUNCH_CHOICES := \
     axolotl-userdebug \
     beryllium-userdebug \
-    enchilada-userdebug
+    enchilada-userdebug \
+    fajita-userdebug

--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -1,4 +1,4 @@
-ifneq ($(filter axolotl beryllium enchilada, $(TARGET_DEVICE)),)
+ifneq ($(filter axolotl beryllium enchilada fajita, $(TARGET_DEVICE)),)
 
 IMAGE_GZ := device/generic/sdm845/shared/prebuilt-kernel/android-$(TARGET_KERNEL_USE)/Image.gz
 DTB := $(wildcard device/generic/sdm845/shared/prebuilt-kernel/android-$(TARGET_KERNEL_USE)/*.dtb)

--- a/fajita/BoardConfig.mk
+++ b/fajita/BoardConfig.mk
@@ -1,0 +1,14 @@
+include device/generic/sdm845/shared/BoardConfig.mk
+
+# Copied from https://github.com/LineageOS/android_device_oneplus_sdm845-common/blob/lineage-16.0/BoardConfigCommon.mk
+# Board Information
+TARGET_BOOTLOADER_BOARD_NAME := fajita
+TARGET_BOARD_PLATFORM := fajita
+TARGET_SCREEN_DENSITY := 400
+
+# Kernel/boot.img Configuration
+BOARD_KERNEL_CMDLINE     += androidboot.hardware=fajita
+
+# Image Configuration
+BOARD_SYSTEMIMAGE_PARTITION_SIZE   := 2998927360
+BOARD_USERDATAIMAGE_PARTITION_SIZE := 57453555712

--- a/fajita/device.mk
+++ b/fajita/device.mk
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2011 The Android Open-Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PRODUCT_COPY_FILES := \
+    $(LOCAL_PATH)/fstab.ramdisk:$(TARGET_COPY_OUT_RAMDISK)/fstab.fajita \
+    $(LOCAL_PATH)/fstab.ramdisk:$(TARGET_COPY_OUT_VENDOR)/etc/fstab.fajita \
+    device/generic/sdm845/shared/etc/audio.sdm845.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio.fajita.xml \
+    device/generic/sdm845/shared/init.sdm845.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.fajita.rc \
+    device/generic/sdm845/shared/init.sdm845.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.fajita.usb.rc \
+    device/generic/sdm845/shared/key_layout.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/fajita.kl
+
+# Build generic Audio HAL
+PRODUCT_PACKAGES := audio.primary.fajita
+
+# Build generic lights HAL
+PRODUCT_PACKAGES += lights.fajita

--- a/fajita/fajita.mk
+++ b/fajita/fajita.mk
@@ -1,0 +1,24 @@
+ifndef TARGET_KERNEL_USE
+TARGET_KERNEL_USE := mainline
+endif
+
+KERNEL_MODS := $(wildcard device/generic/sdm845/shared/prebuilt-kernel/android-$(TARGET_KERNEL_USE)/*.ko)
+
+# Following modules go to vendor partition
+# msm.ko is too big (31M) for ramdisk
+VENDOR_KERN_MODS := %/qcom_q6v5_adsp.ko %/qcom_q6v5_mss.ko %/qcom_q6v5_pas.ko
+BOARD_VENDOR_KERNEL_MODULES := $(filter $(VENDOR_KERN_MODS),$(KERNEL_MODS))
+
+# All other modules go to ramdisk
+BOARD_GENERIC_RAMDISK_KERNEL_MODULES := $(filter-out $(VENDOR_KERN_MODS),$(KERNEL_MODS))
+
+# Inherit the full_base and device configurations
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
+$(call inherit-product, device/generic/sdm845/fajita/device.mk)
+$(call inherit-product, device/generic/sdm845/shared/device.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)
+
+# Product overrides
+PRODUCT_NAME := fajita
+PRODUCT_DEVICE := fajita
+PRODUCT_BRAND := AOSP

--- a/fajita/fstab.ramdisk
+++ b/fajita/fstab.ramdisk
@@ -1,0 +1,3 @@
+/dev/block/platform/soc@0/1d84000.ufshc/by-name/system /system ext4 noatime,ro,errors=panic wait,first_stage_mount,slotselect
+/dev/block/platform/soc@0/1d84000.ufshc/by-name/vendor /vendor ext4 noatime,ro,errors=panic wait,first_stage_mount,slotselect
+/dev/block/platform/soc@0/1d84000.ufshc/by-name/userdata /data		ext4	discard,noatime,noauto_da_alloc,data=ordered,user_xattr,barrier=1	wait,formattable,quota

--- a/shared/init.sdm845.rc
+++ b/shared/init.sdm845.rc
@@ -30,6 +30,7 @@ on early-boot
     chown graphics graphics /sys/kernel/debug/sync/sw_sync
     chmod 777 /sys/kernel/debug/sync/sw_sync
     chown graphics graphics /sys/kernel/debug/sync/info
+    setprop sys.use_memfd true
 
 on zygote-start
     mkdir /data/vendor/wifi 0770 wifi wifi


### PR DESCRIPTION
This commit adds support for Oneplus 6T (fajita), it adds boardconfig files aswell as a new kernel with support for the tfa98xx module provided in my GitHub repo https://github.com/j0sh1x/tfa98xx.git