### PR TITLE
shared: device: remove default bluetooth a2dp lib

### DIFF
--- a/shared/device.mk
+++ b/shared/device.mk
@@ -122,9 +122,8 @@ PRODUCT_PACKAGES += \
     android.hardware.soundtrigger@2.2-impl \
     android.hardware.bluetooth.audio@2.0-impl
 
-# Build default bluetooth a2dp and usb audio HALs
+# Build default audio HALs for bluetooth, remote submix and usb
 PRODUCT_PACKAGES += \
-    audio.a2dp.default \
     audio.bluetooth.default \
     audio.usb.default \
     audio.r_submix.default


### PR DESCRIPTION
See packages/modules/Bluetooth @ f261e756b4f10059b6b90847cd208c95adbd8146

```
build/make/core/tasks/platform_availability_check.mk:37: warning:

Following modules are requested to be installed. But are not available
for platform because they do not have "//apex_available:platform" or
they depend on other modules that are not available for platform

Offending entries:
  audio.a2dp.default:packages/modules/Bluetooth/system/audio_a2dp_hw
  audio.a2dp.default_32:packages/modules/Bluetooth/system/audio_a2dp_hw
```