### PR TITLE
health: detect status file path

### DIFF
--- a/shared/hals/health/HealthImpl.cpp
+++ b/shared/hals/health/HealthImpl.cpp
@@ -6,6 +6,7 @@
 #include <log/log.h>
 #include <android-base/strings.h>
 #include <string>
+#include <fstream>
 
 using ::android::sp;
 using ::android::hardware::Return;
@@ -38,13 +39,34 @@ class HealthImpl : public Health {
 
 extern "C" IHealth* HIDL_FETCH_IHealth(const char* instance) {
     using ::android::hardware::health::V2_1::implementation::HealthImpl;
+
+    static const std::string POWERSUPPLY_DIR = "/sys/class/power_supply";
+
     if (instance != "default"sv) {
         ALOGE("Instance is not supported");
         return nullptr;
     }
     auto config = std::make_unique<healthd_config>();
     InitHealthdConfig(config.get());
-    config->batteryStatusPath = "/sys/class/power_supply/pmi8998_charger/status";
+
+    if (auto supplies = opendir(POWERSUPPLY_DIR.c_str())) {
+        while (dirent *ent = readdir(supplies)) {
+            if ((ent->d_type == DT_DIR && ent->d_name[0] != '.') || ent->d_type == DT_LNK) {
+                std::string supplyPath = POWERSUPPLY_DIR + "/" + ent->d_name;
+                ALOGI("Found %s", supplyPath.c_str());
+                if (auto stream = std::ifstream(supplyPath + "/status")) {
+                    if (stream.good()) {
+                        config->batteryStatusPath = supplyPath.append("/status").c_str();
+                        break;
+                    }
+                }
+            }
+        }
+        closedir(supplies);
+        ALOGI("Using %s", config->batteryStatusPath.c_str());
+    } else {
+        ALOGE("Failed to open %s", POWERSUPPLY_DIR.c_str());
+    }
 
     return new HealthImpl(std::move(config));
 }


### PR DESCRIPTION
Un-hardcode the path to status file by walking /sys/class/power_supply
directories and retaining the first status file found.

Code based on SoMainline lights HAL.