### PR TITLE
Make memfd switch optional

### DIFF
--- a/axolotl/BoardConfig.mk
+++ b/axolotl/BoardConfig.mk
@@ -7,6 +7,7 @@ TARGET_SCREEN_DENSITY := 400
 
 # Kernel/boot.img Configuration
 BOARD_KERNEL_CMDLINE += androidboot.hardware=axolotl
+BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive
 
 ##### Partition handling
 

--- a/axolotl/device.mk
+++ b/axolotl/device.mk
@@ -22,6 +22,9 @@ PRODUCT_COPY_FILES := \
     device/generic/sdm845/shared/init.sdm845.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.axolotl.usb.rc \
     device/generic/sdm845/shared/key_layout.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/axolotl.kl
 
+PRODUCT_COPY_FILES += \
+    device/generic/sdm845/shared/init.memfd.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.memfd.rc
+
 # Audio
 PRODUCT_PACKAGES += audio.primary.axolotl
 

--- a/enchilada/BoardConfig.mk
+++ b/enchilada/BoardConfig.mk
@@ -8,6 +8,7 @@ TARGET_SCREEN_DENSITY := 400
 
 # Kernel/boot.img Configuration
 BOARD_KERNEL_CMDLINE     += androidboot.hardware=enchilada
+BOARD_KERNEL_CMDLINE     += androidboot.selinux=permissive
 
 # Image Configuration
 BOARD_SYSTEMIMAGE_PARTITION_SIZE   := 2998927360

--- a/enchilada/device.mk
+++ b/enchilada/device.mk
@@ -22,6 +22,9 @@ PRODUCT_COPY_FILES := \
     device/generic/sdm845/shared/init.sdm845.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.enchilada.usb.rc \
     device/generic/sdm845/shared/key_layout.kl:$(TARGET_COPY_OUT_VENDOR)/usr/keylayout/enchilada.kl
 
+PRODUCT_COPY_FILES += \
+    device/generic/sdm845/shared/init.memfd.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.memfd.rc
+
 # Build generic Audio HAL
 PRODUCT_PACKAGES := audio.primary.enchilada
 

--- a/shared/BoardConfig.mk
+++ b/shared/BoardConfig.mk
@@ -40,7 +40,7 @@ BOARD_RAMDISK_OFFSET     := 0x01000000
 BOARD_KERNEL_CMDLINE     := console=ttyMSM0,115200n8 earlycon earlyprintk console=tty0 androidboot.console=ttyMSM0 no_console_suspend
 BOARD_KERNEL_CMDLINE     += androidboot.boot_devices=soc@0/1d84000.ufshc
 BOARD_KERNEL_CMDLINE     += firmware_class.path=/vendor/firmware/ init=/init printk.devkmsg=on
-BOARD_KERNEL_CMDLINE     += deferred_probe_timeout=30 androidboot.selinux=permissive
+BOARD_KERNEL_CMDLINE     += deferred_probe_timeout=30
 
 # Image Configuration
 BOARD_FLASH_BLOCK_SIZE := 262144

--- a/shared/init.memfd.rc
+++ b/shared/init.memfd.rc
@@ -1,0 +1,5 @@
+on post-fs-data
+    # set sys.memfd_use to true now that the ashmem is dropped v5.18
+    # https://lore.kernel.org/all/20220315123457.2354812-1-hch@lst.de/.
+    # boots only with selinux=permissive for now
+    setprop sys.use_memfd true

--- a/shared/init.sdm845.rc
+++ b/shared/init.sdm845.rc
@@ -36,11 +36,6 @@ on zygote-start
     mkdir /data/vendor/wifi/wpa 0770 wifi wifi
     mkdir /data/vendor/wifi/wpa/sockets 0770 wifi wifi
 
-on post-fs-data
-    # set sys.memfd_use to true now that the ashmem is dropped v5.18
-    # https://lore.kernel.org/all/20220315123457.2354812-1-hch@lst.de/.
-    setprop sys.use_memfd true
-
 on property:sys.boot_completed=1
     chmod 0755 /sys/kernel/debug/tracing
 


### PR DESCRIPTION
Some devices (e.g. beryllium) still prefer to stick to Ashmem for now, mostly to keep selinux in enforcing mode.

